### PR TITLE
Accept pre-installed PyTorch versions of CPU & GPU.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ networkx==3.2.1
 numpy==1.26.2
 packaging==24.0
 rdkit==2023.9.5
-torch==2.1.0
+torch==2.1.*
 torch_geometric==2.5.3
 tqdm==4.66.4


### PR DESCRIPTION
When the version of pre-installed PyTorch package has device suffix, byteff installation procedures will always force reinstallation of Pytorch.
```
torch               2.1.0+cpu
torch               2.1.0+cu121
```